### PR TITLE
Switching to MonadError

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ import Irssi
 main :: IO ()
 main = do
   let command = Msg Message{cmd="msg", network="freenode", channel="#bottest", message="I am alive!"}
-  stargate <- startWorker
-  sendMessage command stargate
+  Right irsiState <- runExceptT (startWorker "/home/foo/.irssi.sock")
+  sendMessage command (stargate irssiState)
 ```
 
 [simple haskell]: https://www.simplehaskell.org/badges/badge.svg

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -1,6 +1,0 @@
--- You can benchmark your code quickly and effectively with Criterion. See its
--- website for help: <http://www.serpentine.com/criterion/>.
-import Criterion.Main
-
-main :: IO ()
-main = defaultMain [bench "const" (whnf const ())]

--- a/irssi-hs.cabal
+++ b/irssi-hs.cabal
@@ -1,14 +1,14 @@
-cabal-version: 2.2
+cabal-version: 2.4
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 862d3dff084558677f4cee8330bf43815f49d2233cdbeb0206d3a13997a2a152
+-- hash: d0a423a1101275e185d9a53d009b969d8fd30ad45ab5f6dbdcb271dea8ed81c9
 
 name:           irssi-hs
 version:        0.0.0
-synopsis:       A Haskell library to communicate with a running irssi
+synopsis:       A Haskell library to communicate with irssi
 description:    Please see README.md https://github.com/Kleidukos/irssi-hs/blob/master/README.md
 category:       Network
 homepage:       https://github.com/kleidukos/irssi-hs#readme
@@ -35,25 +35,26 @@ library
       Irssi
       Irssi.Worker
       Irssi.Types
+      Prelude
   other-modules:
       Irssi.Utils
-      Prelude
       Paths_irssi_hs
   hs-source-dirs:
       src
   default-extensions: ApplicativeDo BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveAnyClass DeriveFoldable DeriveFunctor DeriveGeneric DeriveLift DeriveTraversable DerivingStrategies DuplicateRecordFields EmptyCase ExistentialQuantification FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving InstanceSigs KindSignatures LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TupleSections TypeApplications TypeFamilies TypeFamilyDependencies TypeOperators
   build-depends:
-      aeson >=1.4.7 && <1.5
-    , base-noprelude >=4.10 && <4.14
-    , bytestring >=0.10.8 && <0.11
-    , containers >=0.6.0 && <0.7
-    , directory >=1.3.3 && <1.4
-    , network >=3.1.1 && <3.2
-    , relude >=0.6.0 && <0.7
-    , text >=1.2.3 && <1.3
-    , unagi-chan >=0.4.1 && <0.5
-    , unordered-containers >=0.2.10 && <0.3
-    , vector >=0.12.1 && <0.13
+      aeson >=1.4 && <1.5
+    , base >=4.10 && <4.15
+    , bytestring >=0.10 && <0.11
+    , containers >=0.6 && <0.7
+    , directory >=1.3 && <1.4
+    , mtl >=2.2 && <2.3
+    , network >=3.1 && <3.2
+    , relude >=0.6 && <0.7
+    , text >=1.2 && <1.3
+    , unagi-chan >=0.4 && <0.5
+    , unordered-containers >=0.2 && <0.3
+    , vector >=0.12 && <0.13
   if impl(ghc >= 8.4.4)
     ghc-options: -Wall -Wcompat -Werror -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wpartial-fields -Wredundant-constraints -fhide-source-paths -Wno-unused-do-bind
   else
@@ -72,10 +73,9 @@ test-suite irssi-hs-tests
       aeson
     , base-noprelude
     , bytestring
+    , hspec >=2.7 && <2.8
     , irssi-hs
     , relude
-    , tasty
-    , tasty-hspec
     , text
     , unordered-containers
     , vector

--- a/package.yaml
+++ b/package.yaml
@@ -7,13 +7,13 @@ github: "kleidukos/irssi-hs"
 license: MIT
 author: "Hécate"
 maintainer: "Hécate"
-synopsis: A Haskell library to communicate with a running irssi
+synopsis: A Haskell library to communicate with irssi
 description: Please see README.md https://github.com/Kleidukos/irssi-hs/blob/master/README.md
 category: Network
 license-file: LICENSE.md
 tested-with: GHC==8.2.2, GHC==8.4.4, GHC==8.6.5, GHC==8.8.3
 verbatim:
-  cabal-version: 2.2
+  cabal-version: 2.4
 
 extra-source-files:
 - CHANGELOG.md
@@ -88,26 +88,26 @@ when:
         - -fhide-source-paths
         - -Wno-unused-do-bind
 
-
-
 library:
   exposed-modules:
     - Irssi
     - Irssi.Worker
     - Irssi.Types
+    - Prelude
 
   dependencies:
-  - aeson                >=1.4.7  && < 1.5
-  - bytestring           >=0.10.8 && < 0.11
-  - containers           >=0.6.0  && < 0.7
-  - text                 >=1.2.3  && <1.3
-  - vector               >=0.12.1 && < 0.13
-  - directory            >=1.3.3  && < 1.4
-  - network              >=3.1.1  && < 3.2
-  - base-noprelude       >=4.10   && < 4.14
-  - relude               >=0.6.0  && < 0.7
-  - unagi-chan           >=0.4.1  && < 0.5
-  - unordered-containers >=0.2.10 && < 0.3
+  - aeson      >= 1.4  && < 1.5
+  - bytestring >= 0.10 && < 0.11
+  - containers >= 0.6  && < 0.7
+  - text       >= 1.2  && < 1.3
+  - mtl        >= 2.2  && < 2.3
+  - vector     >= 0.12 && < 0.13
+  - base       >= 4.10 && < 4.15
+  - directory  >= 1.3  && < 1.4
+  - network    >= 3.1  && < 3.2
+  - relude     >= 0.6  && < 0.7
+  - unagi-chan >= 0.4  && < 0.5
+  - unordered-containers >= 0.2 && < 0.3
   source-dirs: src
 
 tests:
@@ -120,8 +120,9 @@ tests:
     - bytestring
     - irssi-hs
     - relude
-    - tasty
-    - tasty-hspec
+    - hspec >= 2.7 && < 2.8
+    - vector
+    - unordered-containers
     - text
     - unordered-containers
     - vector

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -1,4 +1,4 @@
 module Prelude
-  (module Relude) where
-
+  ( module Relude
+  ) where
 import           Relude

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,27 +3,26 @@ module Main (main) where
 -- Tasty makes it easy to test your code. It is a test framework that can
 -- combine many different types of tests into one suite. See its website for
 -- help: <http://documentup.com/feuerbach/tasty>.
-import qualified Test.Tasty
 -- Hspec is one of the providers for Tasty. It provides a nice syntax for
 -- writing tests. Its website has more info: <https://hspec.github.io>.
 import           Data.Aeson
-import qualified Data.Vector      as V
-import           Test.Tasty.Hspec
+import qualified Data.Vector as V
+import           Test.Hspec
 
 import           Irssi.Types
 
 main :: IO ()
-main = do
-    test <- testSpec "irssi-hs" spec
-    Test.Tasty.defaultMain test
+main = hspec specs
 
-
-spec :: Spec
-spec = parallel $ do
+specs :: Spec
+specs = parallel $ do
     it "is trivially true" $ True `shouldBe` True
     it "JSON encoding for a Message is valid" $ do
       let command = Message "msg" "freenode" "#bottest" "Hey"
       encode command `shouldBe` "[\"command\",\"msg -freenode #bottest Hey\"]"
+    it "JSON encoding for a Print command is valid" $ do
+      let command = Print "Status: OK"
+      encode command `shouldBe` "[\"Irssi::print\",\"Status: OK\"]"
     it "Decoding chatnets message" $ do
       let result = eitherDecodeStrict chatnetJSONPayload
       result `shouldBe` Right chatnetResponse


### PR DESCRIPTION
This PR makes the switch from explicit Either to MonadError-based error management.

Moreover, the `Print` command is added to send a notification to Irssi.